### PR TITLE
feat: add talks pages

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -49,3 +49,147 @@ from = "sponsor-digital-ocean/*"
 to = "https://www.digitalocean.com/deploy?utm_source=influencer_nicktaylor&amp;utm_medium=event&amp;utm_campaign=deploy24"
 status = 302
 force = true
+
+[[redirects]]
+from = "/storybook2021/"
+to = "https://docs.google.com/presentation/d/e/2PACX-1vRVZS5fW795LoPUioxbpIO0k0gaUA7g-J9je8bCaoHKGl678_NgbpNXdsiw3HIrt5BHTLr_l2MmvaNU/pub?start=false&loop=false&delayms=5000"
+status = 302
+force = true
+
+[[redirects]]
+from = "/debug2021/"
+to = "https://docs.google.com/presentation/d/e/2PACX-1vSPMh7JIhImdVWJxUJQOICyib6uETKfpXZ9PDpO-6p-qxn3gW2QxKJHj2ofMxi_s31gAhnwl0nWugOQ/pub?start=false&loop=false&delayms=5000"
+status = 302
+force = true
+
+[[redirects]]
+from = "/hacktoberfest2020/"
+to = "https://www.digitalocean.com/community/tech_talks/getting-the-most-out-of-open-source"
+status = 302
+force = true
+
+[[redirects]]
+from = "/lightning2020/"
+to = "https://docs.google.com/presentation/d/e/2PACX-1vRHfnRD5-ZTiPbBZsT3fNtsB4KcKiemJCLhUxPjtGE5nR2JxmtbtK3_iLSeYbg3ctgVAJEiqPSnAVUQ/pub?start=false&loop=false&delayms=3000"
+status = 302
+force = true
+
+[[redirects]]
+from = "/stream2021/"
+to = "https://docs.google.com/presentation/d/e/2PACX-1vR0cBGMDt11jQ3tP-Z8UPf6BFYXLWX8XzsmfCb26RAYd5gX_ct662YJQrk-fCVp0MOv9tUW4mvBgam8/pub?start=false&loop=false&delayms=5000"
+status = 302
+force = true
+
+[[redirects]]
+from = "/hacktoberfest2021/"
+to = "https://docs.google.com/presentation/d/e/2PACX-1vTUIycMPdV3wRo_nLOhfpiYiUYeML5Bvu4aA1W692VOsvA5p3XIQEC-Y5fPEGWk4uGkpP_z2QNJkJGR/pub?start=false&loop=false&delayms=5000"
+status = 302
+force = true
+
+[[redirects]]
+from = "/codementor2022/"
+to = "https://docs.google.com/presentation/d/e/2PACX-1vQWw0j07xs3gzh8QOUQH6V5kdtX6xPCMmdnSWBfcniNUgqPTYDeMm2CB3BzdiTG0LOKKKg-Ky8r21ko/pub?start=false&loop=false&delayms=5000"
+status = 302
+force = true
+
+[[redirects]]
+from = "/11tyMeetupMay2022/"
+to = "https://docs.google.com/presentation/d/e/2PACX-1vSSj2W1UDxVH2nNBhH0O_5CNia76ri2C0fx8jygK1ZDE6EXs6_CFUZQp64-zyciFaV7xhJWFSYoLsb7/pub?start=false&loop=false&delayms=5000"
+status = 302
+force = true
+
+[[redirects]]
+from = "/ChicagoFresh/"
+to = "https://docs.google.com/presentation/d/e/2PACX-1vQaaGHPbIdb7FPrzbK_1zI1VDhsrEkGJdmwwjRVLoxVz8USPwnw7Jc0kAfDau9gDw22jr2pvd3CB87c/pub?start=false&loop=false&delayms=5000"
+status = 302
+force = true
+
+[[redirects]]
+from = "/fresh/"
+to = "https://docs.google.com/presentation/d/e/2PACX-1vRr2ClzHyIfhamV8rRh92UN5XLDDJKY4E5322hvy_vp6X0cKp3YSayfaSxE6jYG1C8brP3DgZqw6M6u/pub?start=false&loop=false&delayms=5000"
+status = 302
+force = true
+
+[[redirects]]
+from = "/fresh-demo/"
+to = "https://fresh-talk-demo.deno.dev/"
+status = 302
+force = true
+
+[[redirects]]
+from = "/cypress2023/"
+to = "https://docs.google.com/presentation/d/e/2PACX-1vSrKxG3lMKiBXTGH5oDRa4Xn2a23ibQ0jn4iw0UK9VJaoLIF7Fl5GVAEJ5enQ6oEA93huBSBxX2lUdi/pub?start=false&loop=false&delayms=5000"
+status = 302
+force = true
+
+[[redirects]]
+from = "/hack-for-la-2023/"
+to = "https://docs.google.com/presentation/d/e/2PACX-1vTby0GBEWTN0uPPvDlZ5QZKEMnvuKLm-HrqybOiAarJfPWIlMDMOgoqj3vYnS0RA4EuIw7sZAKb23G0/pub?start=false&loop=false&delayms=5000"
+status = 302
+force = true
+
+[[redirects]]
+from = "/slides/fresh/"
+to = "https://docs.google.com/presentation/d/e/2PACX-1vTMFTFQnsUf3XDe-j-Av-ZcMB6YYXXqyOGQIsj0yHvBbRE5mXdfVmb4gpG-qnPWcDYDbZp21pEu32LI/pub?start=false&loop=false&delayms=5000"
+status = 302
+force = true
+
+[[redirects]]
+from = "/demos/fresh/"
+to = "https://so-fresh-demo.deno.dev/"
+status = 302
+force = true
+
+[[redirects]]
+from = "/slides/ext-e2e"
+to = "https://docs.google.com/presentation/d/e/2PACX-1vQtuydI6RpHZ0lrdXrerx_jf8-KvFZRs9fS0QOuPkMv6svIon5I1JWGfJEDqD91XK434sfseStbHPZQ/pub?start=false&loop=false&delayms=5000"
+status = 302
+force = true
+
+[[redirects]]
+from = "/slides/confoo-fresh"
+to = "https://docs.google.com/presentation/d/e/2PACX-1vQsCDGiQMZYh-y90ojCTrWdnjbvYaS4iFH9lDnZcLl0lTH5IpTQnSlfloXDSvWuk9PqNYnJnnlY0UXc/pub?start=false&loop=false&delayms=5000"
+status = 302
+force = true
+
+[[redirects]]
+from = "/slides/ts-generics"
+to = "https://docs.google.com/presentation/d/e/2PACX-1vSQbVQf2G2-lWHloR_3jx16iCVI4xGyAXkhM11zFhqnMgGEp_Dc5LPeqkydnU9JcE-NvorMcZH_iwim/pub?start=false&loop=false&delayms=5000"
+status = 302
+force = true
+
+[[redirects]]
+from = "/slides/compose-24"
+to = "https://docs.google.com/presentation/d/1-YBGThyLLuFHPhgQ7_0xAHJGlLPPHPR6p4Gwgt5nWfI/pub?start=false&loop=false&delayms=5000"
+status = 302
+force = true
+
+[[redirects]]
+from = "/slides/ato24"
+to = "https://docs.google.com/presentation/d/e/2PACX-1vSQtlWFl3LA9mSC9iqML5GItoqwYLLRtvW4WJEyX4cA-jxsiTyh3eckd7P-hklBF1k0N9SVx0SoyVT_/pub?start=false&loop=false&delayms=5000"
+status = 302
+force = true
+
+[[redirects]]
+from = "/slides/xtreme24"
+to = "https://docs.google.com/presentation/d/e/2PACX-1vTdVxuIPmNwqX_fg2vi58v7lk9Vv73azN-TbKn4omb83SOkfgpVH-pQnKawosEIKPkHHgFVAXED3jyo/pub?start=false&loop=false&delayms=5000"
+status = 302
+force = true
+
+[[redirects]]
+from = "/demos/xtreme24"
+to = "https://github.com/nickytonline/xtremejs-2024-demo"
+status = 302
+force = true
+
+[[redirects]]
+from = "/copilot-extension-guide/*"
+to = "/blog/creating-your-first-github-copilot-extension-a-step-by-step-guide-28g0/:splat"
+staus = 301
+force = true
+
+[[redirects]]
+from = "/ato-fresh/"
+to = "https://ato-fresh.deno.dev/"
+status = 302
+force = true

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -32,6 +32,13 @@ const currentPath = pathname.slice(1);
               >Past Streams
             </a>
           </li>
+          <li>
+            <a
+              href="/talks"
+              aria-current={currentPath === "talks" ? "page" : "false"}
+              >Talks
+            </a>
+          </li>
           <li class="relative group">
             <a href="#">Channels</a>
             <div

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -1,0 +1,42 @@
+import { defineCollection, z } from "astro:content";
+
+const talksCollection = defineCollection({
+  type: "content",
+  schema: z.object({
+    title: z.string(),
+    date: z.date(),
+    video: z
+      .object({
+        url: z.string(),
+        type: z.enum(["youtube", "vimeo", "custom"]),
+        image: z
+          .object({
+            url: z.string(),
+            width: z.number(),
+            height: z.number(),
+          })
+          .optional(),
+      })
+      .optional(),
+    venue: z.object({
+      name: z.string(),
+      url: z.string().optional(),
+    }),
+    tags: z.array(z.string()),
+    slideDeck: z.string().optional(),
+    sourceCode: z.string().optional(),
+    additionalLinks: z
+      .array(
+        z.object({
+          title: z.string(),
+          url: z.string(),
+        }),
+      )
+      .optional(),
+  }),
+  sort: (a, b) => b.data.date.getTime() - a.data.date.getTime(),
+});
+
+export const collections = {
+  talks: talksCollection,
+};

--- a/src/content/talks/appwrite-hacktoberfest-kickoff-2021.md
+++ b/src/content/talks/appwrite-hacktoberfest-kickoff-2021.md
@@ -1,0 +1,14 @@
+---
+title: "AppWrite Hacktoberfest Kickoff"
+date: 2021-04-02T12:00:00.000Z
+venue:
+  name: "AppWrite Hacktoberfest Kickoff"
+  url: "https://dev.to/appwrite/appwrites-hacktoberfest-21-journey-4n91"
+tags: ["hacktoberfest", "open source"]
+video:
+  type: "youtube"
+  url: "https://www.youtube.com/watch?v=cyJAz-c1OWs&t=4183s"
+slideDeck: /hacktoberfest2021
+---
+
+Nick Taylor talks about Forem and how you can contribute to the project during and after Hacktoberfest 2021.

--- a/src/content/talks/asking-coding-questions-virtual-coffee-lunch-and-learn-2022.md
+++ b/src/content/talks/asking-coding-questions-virtual-coffee-lunch-and-learn-2022.md
@@ -1,0 +1,16 @@
+---
+title: "Asking Coding Questions"
+date: 2022-05-27T12:00:00.000Z
+venue:
+  name: "Virtual Coffee Lunch & Learn"
+  url: "https://www.youtube.com/playlist?list=PLh9uT23TA65idCyc_orC85RefgY_-fKsG"
+tags: ["career"]
+video:
+  type: "youtube"
+  url: "https://www.youtube.com/watch?v=DVqtr3iwkwQ"
+additionalLinks:
+  - title: "Navigating a new code base"
+    url: "https://dev.to/virtualcoffee/navigating-a-new-code-base-94d"
+---
+
+One of the primary skills you'll need as a developer is asking good questions. We talk about the process of working through a problem and how to ask questions. Because when we ask good questions, we're growing as developers, respecting the time of others, and putting in the work we need to do.

--- a/src/content/talks/automate-syndication-and-ownership-of-your-content-with-eleventy-eleventy-meetup-2022.md
+++ b/src/content/talks/automate-syndication-and-ownership-of-your-content-with-eleventy-eleventy-meetup-2022.md
@@ -1,0 +1,17 @@
+---
+title: "Automate syndication and ownership of your content with Eleventy"
+date: 2022-05-26T12:00:00.000Z
+venue:
+  name: "Eleventy Meetup"
+  url: "https://11tymeetup.dev/events/ep-9-automatic-syndication-and-wordle-on-the-edge/"
+tags: ["eleventy", "automation", "github actions", "netlify"]
+video:
+  type: "youtube"
+  url: "https://www.youtube.com/watch?v=Yy4eHUjLWAs"
+slideDeck: "/11tyMeetupMay2022"
+additionalLinks:
+  - title: "Automate syndication of your content with Eleventy, dev.to, and GitHub Actions"
+    url: "/posts/my-eleventy-meetup-talk-3b2p/"
+---
+
+<p>I use <a href="http://dev.to/">dev.to</a> as a headless CMS. We go through how I pull in my articles, transform and cache them, and how to sync links for Hashnode and dev.to with my own posts. We also touch on GitHub actions as well as deploying to Netlify.</p>

--- a/src/content/talks/back-to-basics-why-html-forms-still-rule-the-web-confoo-2025.md
+++ b/src/content/talks/back-to-basics-why-html-forms-still-rule-the-web-confoo-2025.md
@@ -1,0 +1,13 @@
+---
+title: "Back to Basics: Why HTML Forms Still Rule the Web"
+date: 2025-02-26T12:00:00.000Z
+venue:
+  name: "Confoo 2025"
+  url: "https://confoo.ca/en/2025"
+tags: ["html", "forms", "web development"]
+slideDeck: "https://docs.google.com/presentation/d/e/2PACX-1vRZJIyjyP9r3JDSiEFjuV5CFCf1KH7RuYYvE-zHKYpRZy-nyoVmfYfUUWeWBVWtQBQhCIhb1U46v-21/pub?start=false&loop=false&delayms=3000"
+---
+
+We've strayed too far from the simplicity and power of HTML forms. It's time to undo the damage. Once relegated to basic data collection, forms offer a surprising depth of functionality that's being rediscovered by developers and embraced by modern frameworks like Astro, Fresh, Remix, and Next.js.
+
+Let's rediscover the power of HTML forms and how they should be leveraged in modern web application development.

--- a/src/content/talks/career-lab-q2-2023--watch-your-mentors-interview-each-other.md
+++ b/src/content/talks/career-lab-q2-2023--watch-your-mentors-interview-each-other.md
@@ -1,0 +1,13 @@
+---
+title: "Career Lab Q2 2023: Watch Your Mentors Interview Each Other"
+date: 2023-06-05T12:00:00.000Z
+venue:
+  name: "The Collab Lab: Career Lab"
+  url: "https://the-collab-lab.codes/"
+tags: ["career", "interviewing"]
+video:
+  url: "https://www.youtube.com/watch?v=M_UntxJu-s4"
+  type: "youtube"
+---
+
+In this session, Nick Taylor and EJ Mason run a mock interview where EJ is the interviewer, and Nick is the interviewee. They go over Nick's frontend take-home assignment, and EJ also asks Nick questions about frontend about accessibility, JavaScript, HTML, CSS, and React.

--- a/src/content/talks/debugging-javascript-virtual-coffee-lunch-and-learn.md
+++ b/src/content/talks/debugging-javascript-virtual-coffee-lunch-and-learn.md
@@ -1,0 +1,13 @@
+---
+title: "Debugging JavaScript"
+date: 2021-04-02T12:00:00.000Z
+venue:
+  name: "Virtual Coffee Lunch & Learn"
+  url: "https://www.youtube.com/playlist?list=PLh9uT23TA65idCyc_orC85RefgY_-fKsG"
+tags: ["debugging", "devtools", "javascript"]
+video:
+  { "url": "https://www.youtube.com/watch?v=I9A0Pifn0Uw", "type": "youtube" }
+slideDeck: /debug2021
+---
+
+Learn how to debug JavaScript in the front-end/back-end as well as how to use your browser to debug other issues.

--- a/src/content/talks/end-to-end-testing-for-browser-extensions-confoo-2024.md
+++ b/src/content/talks/end-to-end-testing-for-browser-extensions-confoo-2024.md
@@ -1,0 +1,13 @@
+---
+title: "End to End Testing for Browser Extensions"
+date: 2024-02-21T12:00:00.000Z
+venue:
+  name: "Confoo 2024"
+  url: "https://confoo.ca/en/2024/session/end-to-end-testing-for-browser-extensions"
+tags: ["e2etesting"]
+slideDeck: /slides/ext-e2e
+---
+
+We discuss the fundamentals of browser extensions (Chromium browsers & Firefox), explore the current options available for end-to-end testing, and dive in to some live coding to see it in action.
+
+By the end of this presentation, you'll have the knowledge and skills to implement end-to-end testing for your own browser extension.

--- a/src/content/talks/end-to-end-testing-for-browser-extensions-xtremejs-2024.md
+++ b/src/content/talks/end-to-end-testing-for-browser-extensions-xtremejs-2024.md
@@ -1,0 +1,16 @@
+---
+title: "End to End Testing for Browser Extensions"
+date: 2024-11-12T12:00:00.000Z
+venue:
+  name: "Xtreme.js 2024"
+  url: "https://xtremejs.dev/2024"
+tags: ["e2etesting"]
+video:
+  { "url": "https://www.youtube.com/watch?v=QUkYtRYdXk4", "type": "youtube" }
+slideDeck: /slides/xtreme24
+sourceCode: https://github.com/nickytonline/xtremejs-2024-demo
+---
+
+We discuss the fundamentals of browser extensions (Chromium browsers & Firefox), explore the current options available for end-to-end testing, and dive in to some live coding to see it in action.
+
+By the end of this presentation, you'll have the knowledge and skills to implement end-to-end testing for your own browser extension.

--- a/src/content/talks/end-to-end-testing-with-cypress-the-collab-lab-tech-talks.md
+++ b/src/content/talks/end-to-end-testing-with-cypress-the-collab-lab-tech-talks.md
@@ -1,0 +1,14 @@
+---
+title: "End to End Testing with Cypress"
+date: 2023-03-14T12:00:00.000Z
+venue:
+  name: "The Collab Lab Tech Talks"
+  url: "https://the-collab-lab.codes/tech-talks/"
+tags: ["cypress", "testing"]
+video:
+  { "url": "https://www.youtube.com/watch?v=clj-71r4gEI", "type": "youtube" }
+slideDeck: /cypress2023
+sourceCode: https://github.com/nickytonline/tcl-meetup-cypress
+---
+
+This talk provides an introduction to the Cypress end-to-end (E2E) testing framework. We cover the benefits of E2E testing and then do a short demo using a Collab Lab cohort's project.

--- a/src/content/talks/expert-panel--future-of-testing-front-end-test-fest-2023.md
+++ b/src/content/talks/expert-panel--future-of-testing-front-end-test-fest-2023.md
@@ -1,0 +1,13 @@
+---
+title: "Expert Panel—Future of Testing: How AI Can Accelerate Release Pipelines | Front-End Test Fest 2023"
+date: 2023-06-07T12:00:00.000Z
+venue:
+  name: "Applitools & Netlify Present FRONT-END <TEST>{FEST}"
+  url: "https://applitools.com/resources/events/fetf2023-panel-future-of-testing-how-ai-can-accelerate-release-pipelines/"
+tags: ["testing"]
+video:
+  type: "youtube"
+  url: "https://youtube.com/watch?v=dlw_g3RoeEY"
+---
+
+2023 has been a big year for AI. Joe Colantonio moderates a discussion exploring ways that front-end developers and testers can leverage generative AI and other AI-based tools in their delivery pipelines.

--- a/src/content/talks/expert-panel--trending-tools-and-frameworks-front-end-test-fest-2022.md
+++ b/src/content/talks/expert-panel--trending-tools-and-frameworks-front-end-test-fest-2022.md
@@ -1,0 +1,13 @@
+---
+title: "Expert Panel: Trending Tools and Frameworks – What's Hype and What's Not"
+date: 2022-06-23T12:00:00.000Z
+venue:
+  name: "Applitools & Netlify Present FRONT-END <TEST>{FEST}"
+  url: "https://applitools.com/on-demand-videos/front-end-test-fest-june-2022/"
+tags: ["testing"]
+video:
+  type: "vimeo"
+  url: "https://player.vimeo.com/video/724340575?h=118d599345&color=ff0179&title=0&byline=0&portrait=0"
+---
+
+Joe Colantonio moderates this lively Q&A panel where Tiffany Le-Nguyen, Skyler Brungardt, Nick Taylor, and Dan Giordano share their thoughts on upcoming tools and framework innovations at their respective companies.

--- a/src/content/talks/fresh--a-full-stack-web-framework-for-deno-all-things-open-2024.md
+++ b/src/content/talks/fresh--a-full-stack-web-framework-for-deno-all-things-open-2024.md
@@ -1,0 +1,16 @@
+---
+title: "Fresh: A Full Stack Web Framework for Deno"
+date: 2024-10-29T12:00:00.000Z
+venue:
+  name: "All Things Open 2024"
+  url: "https://2024.allthingsopen.org/"
+tags: ["frameworks", "typescript", "deno", "preact"]
+slideDeck: /slides/ato24
+sourceCode: https://github.com/nickytonline/ato-fresh
+---
+
+Fresh is a web framework based on Web standards built to run on the edge anywhere you can run Deno.
+
+Fresh takes inspiration from existing frameworks to provide features like file-based routing, Islands architecture, server-side rendering and Typescript. Instead of React, it uses Preact.
+
+We'll go through the features and architecture so that you can get up and running with Fresh today.

--- a/src/content/talks/fresh--a-full-stack-web-framework-for-deno-confoo-2024.md
+++ b/src/content/talks/fresh--a-full-stack-web-framework-for-deno-confoo-2024.md
@@ -1,0 +1,16 @@
+---
+title: "Fresh: A Full Stack Web Framework for Deno"
+date: 2024-02-23T12:00:00.000Z
+venue:
+  name: "Confoo 2024"
+  url: "https://confoo.ca/en/2024/session/fresh-a-full-stack-web-framework-for-deno"
+tags: ["frameworks", "typescript", "deno"]
+slideDeck: /slides/confoo-fresh
+sourceCode: https://github.com/nickytonline/fresh-demo
+---
+
+Fresh is a web framework based on Web standards built to run on the edge anywhere you can run Deno.
+
+Fresh takes inspiration from existing frameworks to provide features like file-based routing, Islands architecture, server-side rendering and Typescript.
+
+We'll go through the features and architecture so that you can get up and running with Fresh today.

--- a/src/content/talks/fresh--a-full-stack-web-framework-for-deno-global-summit-for-nodejs-24.md
+++ b/src/content/talks/fresh--a-full-stack-web-framework-for-deno-global-summit-for-nodejs-24.md
@@ -1,0 +1,12 @@
+---
+title: "Fresh: A Full Stack Web Framework for Deno"
+date: 2024-02-21T12:00:00.000Z
+venue:
+  name: "Global Summit for Node.js '24"
+  url: "https://events.geekle.us/nodejs24"
+tags: ["frameworks", "typescript", "deno"]
+slideDeck: /slides/fresh
+sourceCode: https://github.com/nickytonline/fresh-demo
+---
+
+Fresh takes inspiration from existing frameworks to provide features like file-based routing, Islands architecture, server-side rendering and Typescript. We'll cover what makes Fresh possible, i.e. Deno and Preact, then dive into what Fresh is (a metaframework).

--- a/src/content/talks/fresh--a-new-full-stack-web-framework-for-deno-chicagojs-2022.md
+++ b/src/content/talks/fresh--a-new-full-stack-web-framework-for-deno-chicagojs-2022.md
@@ -1,0 +1,15 @@
+---
+title: "Fresh: A New Full Stack Web Framework for Deno"
+date: 2022-12-13T12:00:00.000Z
+venue:
+  name: "ChicagoJS"
+  url: "https://chicagojs.org/"
+tags: ["deno", "typescript"]
+video:
+  type: "youtube"
+  url: "https://www.youtube.com/watch?v=JWjcWQz5g3U&t=2160s"
+slideDeck: /ChicagoFresh
+sourceCode: https://github.com/nickytonline/chicago-js-dec-2022-fresh-demo
+---
+
+Fresh is a web framework based on Web standards built to run on the edge anywhere you can run Deno. Fresh takes inspiration from existing frameworks to provide features like file-based routing, Islands architecture, server-side rendering and Typescript. Another compelling reason to consider Fresh is that there is no build step.

--- a/src/content/talks/fresh--a-new-full-stack-web-framework-for-deno-node-congress.md
+++ b/src/content/talks/fresh--a-new-full-stack-web-framework-for-deno-node-congress.md
@@ -1,0 +1,23 @@
+---
+title: "Fresh: A New Full Stack Web Framework for Deno"
+date: 2023-04-20T12:00:00.000Z
+venue:
+  name: "Node Congress"
+  url: "https://nodecongress.com/"
+tags: ["deno", "typescript"]
+video:
+  {
+    "url": "https://portal.gitnation.org/contents/fresh-a-new-full-stack-web-framework-for-deno",
+    "type": "custom",
+    "image":
+      {
+        "url": "https://gn-portal-og-images.vercel.app/fresh-a-new-full-stack-web-framework-for-deno?v3-1685773499140",
+        "width": 1200,
+        "height": 628,
+      },
+  }
+slideDeck: /fresh
+sourceCode: https://github.com/nickytonline/fresh-talk-demo
+---
+
+Fresh is a web framework based on Web standards built to run on the edge anywhere you can run Deno. Fresh takes inspiration from existing frameworks to provide features like file-based routing, Islands architecture, server-side rendering and Typescript. Another compelling reason to consider Fresh is that there is no build step.

--- a/src/content/talks/getting-started-with-streaming-on-twitch-virtual-coffee-lunch-and-learn-2021.md
+++ b/src/content/talks/getting-started-with-streaming-on-twitch-virtual-coffee-lunch-and-learn-2021.md
@@ -1,0 +1,17 @@
+---
+title: "Getting Started with Streaming on Twitch"
+date: 2021-09-20T12:00:00.000Z
+venue:
+  name: "Virtual Coffee Lunch & Learn"
+  url: "https://www.youtube.com/playlist?list=PLh9uT23TA65idCyc_orC85RefgY_-fKsG"
+tags: ["streaming", "twitch", "obs"]
+video:
+  type: "youtube"
+  url: "https://www.youtube.com/watch?v=aDofyI6E2t4"
+slideDeck: /stream2021
+additionalLinks:
+  - title: "Getting Started with Streaming on Twitch"
+    url: "/blog/getting-started-with-streaming-on-twitch-4im7"
+---
+
+We cover how to get set up and streaming with Twitch using OBS. We cover some basics like live captioning, creating scenes, changing scenes, and having some fun with browser sources to add some interactivity to your stream. If you've been on the fence about whether or not to start streaming, this one's for you!

--- a/src/content/talks/getting-the-most-out-of-open-source-digitalocean-tech-talk-2020.md
+++ b/src/content/talks/getting-the-most-out-of-open-source-digitalocean-tech-talk-2020.md
@@ -1,0 +1,16 @@
+---
+title: "Getting the Most out of Open Source"
+date: 2020-10-01T12:00:00.000Z
+venue:
+  name: "DigitalOcean Tech Talk"
+  url: "https://www.digitalocean.com/community/tech_talks/getting-the-most-out-of-open-source"
+tags: ["open source", "hacktoberfest"]
+video:
+  type: "youtube"
+  url: "https://www.youtube.com/watch?v=Tn3MBiWYeEI"
+slideDeck: /hacktoberfest2020
+---
+
+Nick shares best practices, tips, and tools about how contributors and maintainers of all levels can have happy, productive, and meaningful interactions with the open source community.
+
+Contributing to open source should be fun and rewarding! Whether you are a beginner or seasoned open source enthusiast, you'll come away from this talk refreshed and ready to contribute to or maintain an open source project.

--- a/src/content/talks/getting-the-most-out-of-open-source-hack-for-la-2023.md
+++ b/src/content/talks/getting-the-most-out-of-open-source-hack-for-la-2023.md
@@ -1,0 +1,22 @@
+---
+title: "Getting the Most out of Open Source"
+date: 2023-10-19T12:00:00.000Z
+venue:
+  name: "Hack for LA"
+  url: "https://hackforla.org"
+tags: ["opensource"]
+video:
+  {
+    "url": "https://drive.google.com/file/d/1HPdzQrFP5QwXDnvx7jCFhaWatKTmh-3u/view?usp=sharing",
+    "type": "custom",
+    "image":
+      {
+        "url": "/images/talks/hack-for-la-open-source-talk.png",
+        "width": 1200,
+        "height": 628,
+      },
+  }
+slideDeck: /hack-for-la-2023
+---
+
+Nick Taylor discusses his journey in open source, including his experiences at dev.to, Netlify, and now OpenSauced. Nick shares insights on how to get the most out of open source as a contributor and maintainer.

--- a/src/content/talks/lets-create-a-github-copilot-extension-all-things-open-ai-2025.md
+++ b/src/content/talks/lets-create-a-github-copilot-extension-all-things-open-ai-2025.md
@@ -1,0 +1,20 @@
+---
+title: "Let's Create a GitHub Copilot Extension!"
+date: 2025-03-18T12:00:00.000Z
+venue:
+  name: "All Things Open AI"
+  url: "https://allthingsopen.ai/"
+tags: ["github copilot", "ai", "github copilot extensions"]
+video:
+  type: "youtube"
+  url: "https://www.youtube.com/watch?v=d1ymwRWt9bg"
+slideDeck: https://www.slideshare.net/slideshow/let-s-create-a-github-copilot-extension-nick-taylor-pomerium/277208003
+---
+
+Abstract: Get hands-on in this talk where we'll create a GitHub Copilot Extension from scratch.
+
+We'll use the <a href="https://github.com/copilot-extensions/preview-sdk.js/">Copilot Extensions SDK</a>, and <a href="https://hono.dev">Hono.js</a>, covering best practices like payload validation and progress notifications and error handling.
+
+We'll also go through how to set up a dev environment for debugging, including port forwarding to expose your extension during development as well as the Node.js debugger.
+
+By the end, we'll have a working Copilot extension that the audience can try out live.

--- a/src/content/talks/lets-create-a-github-copilot-extension-confoo-2025.md
+++ b/src/content/talks/lets-create-a-github-copilot-extension-confoo-2025.md
@@ -1,0 +1,19 @@
+---
+title: "Let's Create a GitHub Copilot Extension"
+date: 2025-02-26T12:00:00.000Z
+venue:
+  name: "Confoo 2025"
+  url: "https://confoo.ca/en/2025"
+tags: ["github copilot", "ai", "github copilot extensions"]
+slideDeck: https://docs.google.com/presentation/d/e/2PACX-1vSpG5KEWSVJuXK55F_XNnILVnZ3-9nITE32-yX6l8wn9DQIHQEin9slf6GRe4qTYTLi6JJa6Qu_634g/pub?start=false&loop=false&delayms=3000
+---
+
+GitHub Copilot is everywhere. It's on GitHub.com, in Visual Studio, Visual Studio Code, GitHub Codespaces and more. Did you know you can extend Copilot?
+
+In this hands on talk, you'll learn:
+
+- the architecture of a Copilot extension
+- how to leverage the Copilot extension preview SDK to build GitHub Copilot extensions
+- how to build out your first Copilot extension
+
+We'll wrap things up by taking a peek at a real world example.

--- a/src/content/talks/storybook-2021-the-collab-lab-tech-talks.md
+++ b/src/content/talks/storybook-2021-the-collab-lab-tech-talks.md
@@ -1,0 +1,14 @@
+---
+title: "Storybook 2021"
+date: 2021-03-10T12:00:00.000Z
+venue:
+  name: "The Collab Lab Tech Talks"
+  url: "https://www.meetup.com/tech-talks-by-the-collab-lab/events/276679138/"
+tags: ["storybook", "react", "javascript"]
+video:
+  type: "youtube"
+  url: "https://www.youtube.com/watch?v=ypsD-9qQzYg"
+slideDeck: /storybook2021
+---
+
+Storybook is a tool for building out components and documenting a system of components. It allows you to build components in an isolated environment. This promotes good component practices as well as potentially faster development time as you do not need to rely on the application(s) that consume them.

--- a/src/content/talks/tools-for-web-developers-live-coding-and-debugging-codementor-2022.md
+++ b/src/content/talks/tools-for-web-developers-live-coding-and-debugging-codementor-2022.md
@@ -1,0 +1,14 @@
+---
+title: "Tools for web developers: Live coding and debugging"
+date: 2022-02-10T12:00:00.000Z
+venue:
+  name: "codementor"
+  url: "https://www.codementor.io/events/tools-for-web-devs-dpqk2w3b1r"
+tags: ["devtools", "career"]
+video:
+  type: "youtube"
+  url: "https://www.youtube.com/watch?v=k0nSJ1MtSao"
+slideDeck: /codementor2022
+---
+
+No matter how experienced you are as a developer, one thing that will give you superpowers throughout your career is knowing your tools. Whether it's shortcuts in your favorite editor, the right commands for git, or tools for debugging, they will give your early career a boost, and continue to help you grow and advance as a developer.

--- a/src/content/talks/why-html-forms-still-rule-the-web-netlify-compose-2024.md
+++ b/src/content/talks/why-html-forms-still-rule-the-web-netlify-compose-2024.md
@@ -1,0 +1,13 @@
+---
+title: "Why HTML Forms Still Rule the Web"
+date: 2024-10-03T09:00:00.000Z
+venue:
+  name: "Netlify Compose 2024"
+  url: "https://www.netlify.com/compose/"
+tags: ["html", "forms", "css", "javascript", "frameworks"]
+video: { "url": "https://youtu.be/1U7b7SwKv_s", "type": "youtube" }
+slideDeck: /slides/compose-24
+sourceCode: https://github.com/nickytonline/formfun.dev
+---
+
+We've strayed too far from the simplicity and power of HTML forms. It's time to undo the damage. Once relegated to basic data collection, forms offer a surprising depth of functionality that's being rediscovered by developers and embraced by modern frameworks like Astro, Fresh, Remix, and Next.js. We'll go back to the basics of HTML forms to dig into their history, look at the different input types, validation attributes, and advanced capabilities like the Constraint Validation API. Developers sometimes underestimate the power of CSS for building visually appealing and accessible forms. By using form-specific pseudo-classes like :focus, :hover, :invalid, and :valid, we can enhance the user experience without overcomplicating things by resorting to custom JavaScript. This not only simplifies code but also ensures a consistent user experience across browsers and devices, reinforcing the core strengths of HTML forms. We'll circle back to the present and see how frameworks like Astro, Fresh, Remix, and Next.js are leveraging forms via APIs like the FormData interface. Let's rediscover the power of HTML forms and how they should be leveraged in modern web application development.

--- a/src/content/talks/words-matter-conventional-comments-virtual-coffee-lightning-talks-2020.md
+++ b/src/content/talks/words-matter-conventional-comments-virtual-coffee-lightning-talks-2020.md
@@ -1,0 +1,17 @@
+---
+title: "Words Matter: Conventional Comments"
+date: 2020-11-20T12:00:00.000Z
+venue:
+  name: "Virtual Coffee Lightning Talks"
+  url: "https://virtualcoffee.io"
+tags: ["career", "communication"]
+video:
+  type: "youtube"
+  url: "https://www.youtube.com/watch?v=MMabY-Cm_V4&t=3010s"
+slideDeck: /lightning2020
+additionalLinks:
+  - title: "Conventional Comments"
+    url: "https://conventionalcomments.org"
+---
+
+Virtual Coffee started as a once a week zoom chat in April 2020, and has grown into a community of devs at all stages of the journey, meeting, mentoring, hosting events, and most importantly, making friends. Our mission is to form community, allow room for growth and mentorship at all levels, and to provide a safe space for everyone interested in tech. Nick goes over conventional comments and how they can help you and your team.

--- a/src/content/talks/zero-trust--from-airports-to-identity-aware-proxies-sreday-london-2025-q1.md
+++ b/src/content/talks/zero-trust--from-airports-to-identity-aware-proxies-sreday-london-2025-q1.md
@@ -1,0 +1,13 @@
+---
+title: "Zero Trust: From Airports to Identity-Aware Proxies"
+date: 2025-03-27T00:00:00.000Z
+venue:
+  name: "SREday London 2025 Q1"
+  url: "https://sreday.com/2025-london-q1"
+tags: ["security", "zerotrust", "sre"]
+video:
+  { "url": "https://www.youtube.com/watch?v=g126UIGo2t4", "type": "youtube" }
+slideDeck: https://docs.google.com/presentation/d/e/2PACX-1vQjO55qjKAN1SgNQMg1WcecU3w0_dVm7eQpUoBoUSrMwPzTYDvVfqsmB9OL1XMDdEoSwWpO-IMKLMTH/pub?start=false&loop=false&delayms=5000&slide=id.p
+---
+
+Nick Taylor presents a practical introduction to Zero Trust, drawing analogies from airport security to modern identity-aware proxies. Delivered at SREday London 2025 Q1.

--- a/src/content/talks/zero-trust--from-airports-to-identity-aware-proxies-sreday-redmond-2025-q2.md
+++ b/src/content/talks/zero-trust--from-airports-to-identity-aware-proxies-sreday-redmond-2025-q2.md
@@ -1,0 +1,13 @@
+---
+title: "Zero Trust: From Airports to Identity-Aware Proxies"
+date: 2025-04-14T00:00:00.000Z
+venue:
+  name: "SREday Redmond 2025 Q2"
+  url: "https://sreday.com/2025-redmond-q2/"
+tags: ["security", "zerotrust", "sre"]
+video:
+  { "url": "https://www.youtube.com/watch?v=t7C0EUtmrj8", "type": "youtube" }
+slideDeck: https://docs.google.com/presentation/d/e/2PACX-1vQjO55qjKAN1SgNQMg1WcecU3w0_dVm7eQpUoBoUSrMwPzTYDvVfqsmB9OL1XMDdEoSwWpO-IMKLMTH/pub?start=false&loop=false&delayms=5000&slide=id.p
+---
+
+Nick Taylor presents a practical introduction to Zero Trust, drawing analogies from airport security to modern identity-aware proxies. Delivered at SREday Redmond 2025 Q2.

--- a/src/content/talks/zero-trust--from-airports-to-identity-aware-proxies-sreday-san-francisco-2025-q2.md
+++ b/src/content/talks/zero-trust--from-airports-to-identity-aware-proxies-sreday-san-francisco-2025-q2.md
@@ -1,0 +1,13 @@
+---
+title: "Zero Trust: From Airports to Identity-Aware Proxies"
+date: 2025-04-11T00:00:00.000Z
+venue:
+  name: "SREday San Francisco 2025 Q2"
+  url: "https://sreday.com/2025-san-francisco-q2/"
+tags: ["security", "zerotrust", "sre"]
+video:
+  { "url": "https://www.youtube.com/watch?v=NFn2kxVsAfE", "type": "youtube" }
+slideDeck: https://docs.google.com/presentation/d/e/2PACX-1vQjO55qjKAN1SgNQMg1WcecU3w0_dVm7eQpUoBoUSrMwPzTYDvVfqsmB9OL1XMDdEoSwWpO-IMKLMTH/pub?start=false&loop=false&delayms=5000&slide=id.p
+---
+
+Nick Taylor presents a practical introduction to Zero Trust, drawing analogies from airport security to modern identity-aware proxies. Delivered at SREday San Francisco 2025 Q2.

--- a/src/pages/talks.astro
+++ b/src/pages/talks.astro
@@ -1,0 +1,46 @@
+---
+import { getCollection } from "astro:content";
+import Layout from "../layouts/MainLayout.astro";
+const talks = await getCollection("talks");
+const sortedTalks = talks.sort(
+  (a, b) => b.data.date.getTime() - a.data.date.getTime(),
+);
+---
+
+<Layout title="Talks | Nick Taylor">
+  <main class="mt-4 md:mt-8 lg:mt-16">
+    <div class="grid gap-8">
+      <h1>Talks</h1>
+      <ul class="grid gap-8">
+        {
+          sortedTalks.map((talk) => {
+            // Derive slug from entry id (filename without extension)
+            const slug = talk.id.replace(/^talks\//, "").replace(/\.md$/, "");
+            return (
+              <li class="flex items-center before:content-['🎙️'] before:mr-2 before:inline-block before:text-2xl">
+                <a href={`/talks/${slug}`} class="block group">
+                  <article>
+                    <h2>
+                      <a href={`/talks/${slug}`}>{talk.data.title}</a>
+                    </h2>
+                    <div>
+                      <time datetime={talk.data.date.toISOString()}>
+                        {talk.data.date.toLocaleDateString("en-US", {
+                          year: "numeric",
+                          month: "long",
+                          day: "numeric",
+                        })}
+                      </time>
+                      {" \u2022 "}
+                      {talk.data.venue.name}
+                    </div>
+                  </article>
+                </a>
+              </li>
+            );
+          })
+        }
+      </ul>
+    </div>
+  </main>
+</Layout>

--- a/src/pages/talks/[slug].astro
+++ b/src/pages/talks/[slug].astro
@@ -1,0 +1,148 @@
+---
+import { getEntry } from "astro:content";
+import Layout from "../../layouts/MainLayout.astro";
+
+const { slug } = Astro.params;
+
+if (!slug) {
+  throw new Error("Talk not found");
+}
+
+const talk = await getEntry("talks", slug);
+
+if (!talk) {
+  throw new Error("Talk not found");
+}
+
+const {
+  title,
+  date,
+  venue,
+  tags = [],
+  video,
+  slideDeck,
+  sourceCode,
+  additionalLinks = [],
+} = talk.data;
+const summary = talk.body;
+---
+
+<Layout title={`${title} | Nick Taylor`}>
+  <main class="mt-4 md:mt-8 lg:mt-16">
+    <article class="max-w-3xl grid gap-8">
+      <header>
+        <h1
+          class="text-4xl font-extrabold leading-tight mb-2 relative inline-block"
+        >
+          {title}
+        </h1>
+        <div class="text-2xl text-gray-600 mt-2 relative inline-block">
+          <time datetime={date.toISOString()}>
+            {
+              date.toLocaleDateString("en-US", {
+                year: "numeric",
+                month: "long",
+                day: "numeric",
+              })
+            }
+          </time>
+          {` \u2022 ${venue.name}`}
+        </div>
+      </header>
+
+      {
+        video && (
+          <div class="my-4">
+            {video.type === "youtube" && (
+              <iframe
+                width="560"
+                height="315"
+                src={video.url
+                  .replace("watch?v=", "embed/")
+                  .replace("&t=", "?start=")}
+                title="YouTube video player"
+                frameborder="0"
+                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                allowfullscreen
+                class="w-full max-w-2xl aspect-video rounded shadow"
+              />
+            )}
+            {video.type === "vimeo" && (
+              <iframe
+                src={video.url.replace("vimeo.com/", "player.vimeo.com/video/")}
+                width="640"
+                height="360"
+                frameborder="0"
+                allow="autoplay; fullscreen; picture-in-picture"
+                allowfullscreen
+                class="w-full max-w-2xl aspect-video rounded shadow"
+                title="Vimeo video player"
+              />
+            )}
+            {video.type === "custom" && video.image && (
+              <a href={video.url} target="_blank" rel="noopener noreferrer">
+                <img
+                  src={video.image.url}
+                  width={video.image.width}
+                  height={video.image.height}
+                  alt="Talk video preview"
+                  class="rounded shadow mx-auto"
+                />
+              </a>
+            )}
+          </div>
+        )
+      }
+      {
+        !video && (
+          <div class="text-center text-gray-600">
+            No video available for this talk
+          </div>
+        )
+      }
+
+      <div class="prose max-w-none">
+        {summary}
+      </div>
+
+      <footer class="flex flex-wrap gap-4 mt-6">
+        {
+          slideDeck && (
+            <a href={slideDeck} target="_blank">
+              View Slides
+            </a>
+          )
+        }
+        {
+          sourceCode && (
+            <a href={sourceCode} target="_blank">
+              Source Code
+            </a>
+          )
+        }
+        {
+          additionalLinks.map((link: { title: string; url: string }) => (
+            <a
+              href={link.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              class="inline-flex items-center gap-2 text-sm text-blue-600 hover:text-blue-800"
+            >
+              {link.title}
+            </a>
+          ))
+        }
+      </footer>
+
+      <div class="flex flex-wrap gap-2 mt-4">
+        {
+          tags.map((tag: string) => (
+            <span class="rounded-full bg-gray-100 px-3 py-1 text-sm text-gray-600">
+              {tag}
+            </span>
+          ))
+        }
+      </div>
+    </article>
+  </main>
+</Layout>


### PR DESCRIPTION
Adds a talks page with a list of all the talks I've given and each talk has their own dedicated page. The feature leverages Astro content collections.

![CleanShot 2025-05-13 at 22 17 55@2x](https://github.com/user-attachments/assets/6955b352-4de5-450d-b26d-e315969dbd2f)

![CleanShot 2025-05-13 at 22 18 34@2x](https://github.com/user-attachments/assets/df2c5eb9-c1a7-40c3-8be2-91f7cdf1a26a)


