### PR TITLE
chore: add environment configuration and integrate varlock

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,1 @@
+URL="http://localhost:${PORT}"

--- a/.env.schema
+++ b/.env.schema
@@ -1,0 +1,23 @@
+# This env file uses @env-spec - see https://varlock.dev/env-spec for more info
+#
+# @defaultRequired=infer @defaultSensitive=false
+# @generateTypes(lang=ts, path=env.d.ts)
+# @envFlag=APP_ENV
+# ----------
+
+# @type=enum("development", "staging", "test", "production")
+APP_ENV="development"
+
+# The Airtable API key for accessing guest info
+# @required @sensitive
+AIRTABLE_API_KEY=
+# @required  @sensitive
+AIRTABLE_STREAM_GUEST_BASE_ID=
+CLOUDINARY_CLOUD_NAME="nickytonline"
+
+# @type=port
+PORT=4321
+
+# URL from Netlify (deploy preview URL, prod URL etc.)
+# @required
+URL=

--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,12 @@ pnpm-debug.log*
 
 # environment variables
 .env
+.env.local
+.env.*.local
 .env.production
+
+#varlock artifact
+env.d.ts
 
 # macOS-specific files
 .DS_Store

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,6 +4,9 @@ import netlify from "@astrojs/netlify";
 
 import react from "@astrojs/react";
 
+import varlockintegration from "@varlock/astro-integration";
+import { ENV } from "varlock/env";
+
 // https://astro.build/config
 export default defineConfig({
   integrations: [
@@ -11,7 +14,11 @@ export default defineConfig({
       applyBaseStyles: false,
     }),
     react(),
+    varlockintegration(),
   ],
   output: "server",
   adapter: netlify(),
+  server: {
+    port: ENV.PORT,
+  },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@astrojs/netlify": "^6.5.7",
         "@astrojs/react": "^4.3.0",
         "@astrojs/tailwind": "^6.0.2",
+        "@varlock/astro-integration": "^0.0.5",
         "astro": "^5.13.2",
         "gsap": "^3.12.5",
         "lint-staged": "^15.2.10",
@@ -19,7 +20,8 @@
         "marked": "^12.0.1",
         "rss-parser": "^3.13.0",
         "tailwindcss": "^3.4.1",
-        "typescript": "^5.3.3"
+        "typescript": "^5.3.3",
+        "varlock": "^0.0.10"
       },
       "devDependencies": {
         "astro-eslint-parser": "^1.1.0",
@@ -756,6 +758,12 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@env-spec/parser": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@env-spec/parser/-/parser-0.0.4.tgz",
+      "integrity": "sha512-ysXTCuq9O+hznIDWD+bHQT/EPJU+C0HGdKvBsZ0LHE+ESYwOM1YXGqButXsxtHd3Dj33mNPUWLqLuVO4IhX4WA==",
+      "license": "MIT"
     },
     "node_modules/@envelop/instrumentation": {
       "version": "1.0.0",
@@ -4416,6 +4424,12 @@
         "win32"
       ]
     },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "license": "MIT"
+    },
     "node_modules/@shikijs/core": {
       "version": "3.9.2",
       "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.9.2.tgz",
@@ -4482,6 +4496,18 @@
       "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
       "license": "MIT"
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.17",
@@ -4912,6 +4938,39 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.1.tgz",
       "integrity": "sha512-fEzPV3hSkSMltkw152tJKNARhOupqbH96MZWyRjNaYZOMIzbrTeQDG+MTc6Mr2pgzFQzFxAfmhGDNP5QK++2ZA=="
+    },
+    "node_modules/@varlock/astro-integration": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@varlock/astro-integration/-/astro-integration-0.0.5.tgz",
+      "integrity": "sha512-K2z9PfSlYCFfE7l6o1ee1/Apca6GnCSIkRUUTP0Nan24Yp4VKwxcPWHb9NNM+bReqULLnY/HmbieTQYhGM8pnw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.1"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "astro": ">=4",
+        "varlock": "^0.0.10"
+      }
+    },
+    "node_modules/@varlock/astro-integration/node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@vercel/nft": {
       "version": "0.29.4",
@@ -11707,6 +11766,18 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/parse-ms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/parse5": {
       "version": "7.2.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.2.1.tgz",
@@ -12175,6 +12246,21 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/pretty-ms": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.2.0.tgz",
+      "integrity": "sha512-4yf0QO/sllf/1zbZWYnvWw3NxCQwLXKzIj0G849LSufP15BXKM0rbD2Z3wVnkMfjdn/CB0Dpp444gYAACdsplg==",
+      "license": "MIT",
+      "dependencies": {
+        "parse-ms": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/prismjs": {
@@ -14118,6 +14204,180 @@
       "license": "ISC",
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/varlock": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/varlock/-/varlock-0.0.10.tgz",
+      "integrity": "sha512-18SF1sj1c2BShIh4RvMijKsmWc/jx/ZuD+aWdrPva+XnNzs9zU3NnJEOeZ0AdxsdMGT/12OoQMfZyN5QUDJ7pA==",
+      "license": "MIT",
+      "dependencies": {
+        "@env-spec/parser": "^0.0.4",
+        "debug": "^4.4.1",
+        "execa": "^9.6.0",
+        "which": "^5.0.0"
+      },
+      "bin": {
+        "varlock": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/varlock/node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/varlock/node_modules/execa": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.0.tgz",
+      "integrity": "sha512-jpWzZ1ZhwUmeWRhS7Qv3mhpOhLfwI+uAX4e5fOcXqwMR7EcJ0pj2kV1CVzHVMX/LphnKWD3LObjZCoJ71lKpHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.0",
+        "human-signals": "^8.0.1",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^6.0.0",
+        "pretty-ms": "^9.2.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/varlock/node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/varlock/node_modules/human-signals": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/varlock/node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/varlock/node_modules/isexe": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
+      "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/varlock/node_modules/npm-run-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/varlock/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/varlock/node_modules/strip-final-newline": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/varlock/node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/varlock/node_modules/which": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
+      "integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^3.1.1"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/vfile": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@astrojs/netlify": "^6.5.7",
     "@astrojs/react": "^4.3.0",
     "@astrojs/tailwind": "^6.0.2",
+    "@varlock/astro-integration": "^0.0.5",
     "astro": "^5.13.2",
     "gsap": "^3.12.5",
     "lint-staged": "^15.2.10",
@@ -22,7 +23,8 @@
     "marked": "^12.0.1",
     "rss-parser": "^3.13.0",
     "tailwindcss": "^3.4.1",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "varlock": "^0.0.10"
   },
   "optionalDependencies": {
     "@rollup/rollup-linux-x64-gnu": "^4.9.5"

--- a/src/pages/feed.ts
+++ b/src/pages/feed.ts
@@ -4,8 +4,9 @@ import {
   get2Full2StackStreamSchedule,
   type StreamGuestInfo,
 } from "../utils/schedule-utils";
+import { ENV } from "varlock/env";
 
-const SITE_URL = import.meta.env.URL || "https://nickyt.live";
+const SITE_URL = ENV.URL;
 
 /**
  * Escapes a string for XML.

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,12 +5,7 @@ import {
   getStreamSchedule,
   get2Full2StackStreamSchedule,
 } from "../utils/schedule-utils";
-
-const { AIRTABLE_STREAM_GUEST_BASE_ID, AIRTABLE_API_KEY } = import.meta.env;
-
-if (!AIRTABLE_API_KEY || !AIRTABLE_STREAM_GUEST_BASE_ID) {
-  throw new Error("Missing required environment variables");
-}
+import { ENV } from "varlock/env";
 
 const locale =
   Astro.request.headers.get("Accept-Language")?.split(",")[0] ||
@@ -18,8 +13,8 @@ const locale =
   "en-US";
 
 const schedule = await getStreamSchedule({
-  apiKey: AIRTABLE_API_KEY,
-  baseId: AIRTABLE_STREAM_GUEST_BASE_ID,
+  apiKey: ENV.AIRTABLE_API_KEY,
+  baseId: ENV.AIRTABLE_STREAM_GUEST_BASE_ID,
 });
 
 const cfeSchedule = await get2Full2StackStreamSchedule();


### PR DESCRIPTION
This pull request introduces environment variable management using the [Varlock library](https://varlock.dev) and its Astro integration. It standardizes how environment variables are accessed throughout the codebase, improves type safety, and updates configuration files and dependencies accordingly.

Related Live Stream:

<a href="https://www.youtube.com/watch?v=AG9rTCZwokw" title="Levelling up Astro env with Varlock">
<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/8f7252ad-21ae-4158-8a92-aa98ccab19f7" />
</a>

**Environment variable management and configuration:**

* Added `.env.schema` file with Varlock annotations to define and document required environment variables, their types, and defaults. This enables type generation and validation for environment variables.
* Added `.env.development` with a `URL` variable referencing the `PORT` variable for local development.

**Dependency and integration updates:**

* Added `@varlock/astro-integration` and `varlock` to `package.json` dependencies to enable Varlock environment management.
* Updated `astro.config.mjs` to use the Varlock Astro integration and set the server port from the `ENV.PORT` variable.

**Codebase refactoring for environment variable usage:**

* Replaced direct usage of `import.meta.env` with `ENV` from `varlock/env` in both `src/pages/feed.ts` and `src/pages/index.astro`, ensuring consistent and type-safe access to environment variables. [[1]](diffhunk://#diff-d5769812b31a075e14f44945ecc6f354c4963398c7e10709ea49cb15acaacbadR7-R9) [[2]](diffhunk://#diff-95d291e9ce4c8739cc7e65ff7bf0838dd5294cf39ab787ba51a42d08fb2df663L8-R17)